### PR TITLE
some bug fixes

### DIFF
--- a/connect-prerenderer.js
+++ b/connect-prerenderer.js
@@ -46,7 +46,7 @@ function getTargetURL(req, options) {
       var prefix = options['targetPrefix'] || 'http://' + req.headers.host;
       var replacer = options['targetReplacer'] || function(url) {
           url = '/' + url.substring(prerenderURLPrefixLengthPlusOne);
-          var match = url.match(/HASH([-_/:])?/);
+          var match = url.match(/HASH([-_\/:])?/);
           if (match) {
             url = url.replace(/HASH/, '#');
             if (match[1]) {


### PR DESCRIPTION
- use res.status() instead of res.statusCode
- remove res.setHeaders('content-length') due to break content
- modify unescaped regexp'
