### PR TITLE
Change googlebot targetGenerator to work with empty _escaped_fragment_.

### DIFF
--- a/connect-prerenderer.js
+++ b/connect-prerenderer.js
@@ -30,16 +30,17 @@ var http = require('http');
 var URL = require('url');
 var request = require('request');
 var jsdom = require('jsdom');
+var urlLib = require('url');
 
 var targetGeneratorMap = {
 
   'googlebot': function(url, options, req) {
     var prefix = options['targetPrefix'] || 'http://' + req.headers.host;
-    var fragment = req.query['_escaped_fragment_'];
-    if (!fragment) {
+    var fragment = urlLib.parse(url, true).query['_escaped_fragment_'];
+    if (!fragment && fragment !== '') {
       return null;
     }
-    url = url.replace(/[?&]_escaped_fragment_=[^&]+/, '');
+    url = url.replace(/[?&]_escaped_fragment_=[^&]*/, '');
     return prefix + url + '#!' + fragment;
   },
 


### PR DESCRIPTION
According to section `3. Handle pages without hash fragments` section of https://developers.google.com/webmasters/ajax-crawling/docs/getting-started, if a ajax page has the meta tag `<meta name="fragment" content="!">`, the crawler will crawl the page with an empty `_escaped_fragment_` parameter, e.g. 'www.example.com?_escaped_fragment_='.
