### PR TITLE
Fix for prerendered content sometimes prepended by 'null'

### DIFF
--- a/connect-prerenderer.js
+++ b/connect-prerenderer.js
@@ -118,7 +118,8 @@ function renderURL(url, headers, options, callback) {
         var content;
         try {
           document.body.setAttribute('data-prerendered', 'true');
-          content = document.doctype + document.innerHTML;
+          content = [document.doctype, document.innerHTML]
+            .filter(function (val) { return val; }).join();
         } catch (err) {
           callback(err);
           return;

--- a/test/e2e/basicTest.js
+++ b/test/e2e/basicTest.js
@@ -29,6 +29,12 @@ describe('main e2e test for prerenderer', function() {
     expect(element('div[id="id001"]').text()).toBe('simple1');
   });
 
+  it('prerendered html shouldn\'t have \'null\' in place of the doctype',
+    function() {
+    browser().navigateTo('/PRERENDER/simpledom.html');
+    expect(element('body').html()).not().toMatch(/^null/);
+  });
+
   it('should get prerendered /simplejs.html', function() {
     browser().navigateTo('/PRERENDER-simplejs.html');
     expect(element('div[id="id002"]').text()).toBe('simple2');


### PR DESCRIPTION
Hey - I added a failing test for this issue I was seeing:
![screen shot 2014-05-19 at 10 11 42 pm](https://cloud.githubusercontent.com/assets/59292/3022218/24dfe852-dfc4-11e3-8e93-f34b21b86be6.png)

And I changed some code in the prerenderer to not prepend `document.doctype` to the prerendered content if it's `null`. Let me know if this doesn't make sense.
