### PR TITLE
Fix bug where the prerendered doc would contain nested html tags

### DIFF
--- a/connect-prerenderer.js
+++ b/connect-prerenderer.js
@@ -129,8 +129,7 @@ function renderURL(url, headers, options, callback) {
     };
     timer = setTimeout(done, timeout);
     try {
-      document = jsdom.jsdom('', null, {
-        deferClose: true,
+      document = jsdom.jsdom(body, null, {
         url: url,
         cookie: headers.cookie,
         cookieDomain: cookieDomain,
@@ -143,8 +142,6 @@ function renderURL(url, headers, options, callback) {
         document.parentWindow.console = console;
       }
       document.onprerendered = done;
-      document.write(body);
-      document.close();
     } catch (err) {
       if (timer) {
         clearTimeout(timer);

--- a/test/e2e/basicTest.js
+++ b/test/e2e/basicTest.js
@@ -35,6 +35,12 @@ describe('main e2e test for prerenderer', function() {
     expect(element('body').html()).not().toMatch(/^null/);
   });
 
+  xit('prerendered html shouldn\'t have nested html tags', function() {
+    browser().navigateTo('/PRERENDER/simpledom.html');
+    // FIXME: the following line doesn't get the document correctly
+    expect(element('document').html()).not().toMatch(/<html>.*<html>/);
+  });
+
   it('should get prerendered /simplejs.html', function() {
     browser().navigateTo('/PRERENDER-simplejs.html');
     expect(element('div[id="id002"]').text()).toBe('simple2');


### PR DESCRIPTION
The 'body' parameter returned from request() is the full document, so pass that directly to `jsdom.jsdom()`. When initializing jsdom with an empty string as the doc as we were doing, jsdom creates `<html>...</html>`, and we were getting nested `<html>` and `<body>` elements.

A before and after example of what I'm referring to:

345c23dc8019afe94ad20352f861dd6d5525f597
![screen shot 2014-05-20 at 7 55 21 pm](https://cloud.githubusercontent.com/assets/59292/3034736/4313d728-e07a-11e3-9868-74b7fef1397f.png)

f57d17539789b2e0acbd91365e69b93b5e59e624
![screen shot 2014-05-20 at 7 56 26 pm](https://cloud.githubusercontent.com/assets/59292/3034742/63065560-e07a-11e3-9392-78e248c55324.png)

I also have a test in here that I've xit'ed out because I couldn't figure out yet how to look at the entire document in karma-jasmine or whatever this is.
