### PR TITLE
update jsdom & fix memory leak

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
 language: node_js
 nodejs:
   - 0.10
+  - 0.12

--- a/connect-prerenderer.js
+++ b/connect-prerenderer.js
@@ -27,9 +27,7 @@
 /* jshint evil: true */
 
 var http = require('http');
-var urlLib = require('url');
-var request = require('request');
-var jsdom = require('jsdom');
+var spawn = require('child_process').spawn;
 
 var targetGeneratorMap = {
 
@@ -83,72 +81,53 @@ function getTargetURL(req, options) {
   return targetGenerator(req.url, options, req);
 }
 
-function filterHeaders(headers) {
-  var newHeaders = {};
-  for (var key in headers) {
-    if (key === 'host' || key === 'cookie' ||
-      (key.lastIndexOf('accept', 0) === 0 && key !== 'accept-encoding')) {
-      newHeaders[key] = headers[key];
-    }
-  }
-  return newHeaders;
-}
-
 function renderURL(url, headers, options, callback) {
+  var renderer = spawn(process.argv[0], [__dirname + '/urlRenderer.js', JSON.stringify([url, headers, options])], {
+    stdio: ['ignore', 'pipe', 'pipe']
+  });
+
+  renderer.stderr.pipe(process.stderr);
+
+  var allData = new Buffer('');
+  renderer.stdout.on('data', function(data) {
+    allData = Buffer.concat([allData, data]);
+  });
+
   var timeout = (options && options.timeout ? options.timeout : 5000);
-  var cookieDomain = options && options.cookieDomain;
-  request({
-    uri: urlLib.parse(url),
-    headers: filterHeaders(headers)
-  }, function(err, res, body) {
-    if (err) {
-      callback(err);
-      return;
+  var timer = null;
+  function done(err) {
+    if (timer) {
+      clearTimeout(timer);
+      timer = null;
     }
-    if (res.statusCode != 200) {
-      callback(res.statusCode);
-      return;
-    }
-    var document;
-    var timer = null;
-    var done = function() {
-      if (timer) {
-        clearTimeout(timer);
-        timer = null;
-        var content;
-        try {
-          document.body.setAttribute('data-prerendered', 'true');
-          content = jsdom.serializeDocument(document);
-        } catch (err) {
-          callback(err);
-          return;
-        }
-        callback(null, content, res.headers);
-      }
-    };
-    timer = setTimeout(done, timeout);
+    renderer.kill('SIGKILL');
+
+    var args
     try {
-      document = jsdom.jsdom(body, {
-        url: url,
-        cookie: headers.cookie,
-        cookieDomain: cookieDomain,
-        features: {
-          FetchExternalResources: ['script'],
-          ProcessExternalResources: ['script']
-        }
-      });
-      if (options && options.attachConsole) {
-        document.parentWindow.console = console;
-      }
-      document.onprerendered = done;
-    } catch (err) {
-      if (timer) {
-        clearTimeout(timer);
-        timer = null;
-      }
-      callback(err);
-      return;
+      args = JSON.parse(allData);
     }
+    catch(e) {
+      args = [e];
+    }
+
+    if (args[0] && !(args[0] instanceof Error))
+      args[0] = new Error(args[0]);
+    else if (err)
+      args[0] = err;
+
+    callback.apply(null, args);
+  }
+
+  timer = setTimeout(function() {
+    console.log('Timouted after ' + timeout + ' ms');
+    done();
+  }, timeout);
+
+  renderer.stdout.on('end', done);
+
+  renderer.stdout.on('error', function(error) {
+    renderer.kill('SIGKILL');
+    callback(err);
   });
 }
 

--- a/connect-prerenderer.js
+++ b/connect-prerenderer.js
@@ -118,8 +118,7 @@ function renderURL(url, headers, options, callback) {
         var content;
         try {
           document.body.setAttribute('data-prerendered', 'true');
-          content = [document.doctype, document.innerHTML]
-            .filter(function (val) { return val; }).join();
+          content = jsdom.serializeDocument(document);
         } catch (err) {
           callback(err);
           return;
@@ -129,7 +128,7 @@ function renderURL(url, headers, options, callback) {
     };
     timer = setTimeout(done, timeout);
     try {
-      document = jsdom.jsdom(body, null, {
+      document = jsdom.jsdom(body, {
         url: url,
         cookie: headers.cookie,
         cookieDomain: cookieDomain,
@@ -165,7 +164,7 @@ function prerenderer(options) {
           res.setHeader('content-length', Buffer.byteLength(content));
           res.end(content);
         } else if (err) {
-          console.log('renderURL failed: ', err);
+          console.log('renderURL failed: ', err.stack);
           next();
         } else {
           //console.log('prerendered:' , content);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "connect-prerenderer",
   "description": "Express/connect middleware to pre-render ajax page for non-ajax browsers, especially using angular.js",
-  "version": "0.6.4",
+  "version": "0.7.0",
   "author": "Daishi Kato <daishi@axlight.com>",
   "dependencies": {
     "jsdom": "3.1.2",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.6.4",
   "author": "Daishi Kato <daishi@axlight.com>",
   "dependencies": {
-    "jsdom": "0.10.5",
+    "jsdom": "3.1.2",
     "request": "~2.14.0"
   },
   "devDependencies": {

--- a/urlRenderer.js
+++ b/urlRenderer.js
@@ -1,0 +1,109 @@
+#!/usr/bin/env node
+
+'use strict';
+
+var urlLib = require('url');
+var request = require('request');
+var jsdom = require('jsdom');
+
+function filterHeaders(headers) {
+  var newHeaders = {};
+  for (var key in headers) {
+    if (key === 'host' || key === 'cookie' ||
+      (key.lastIndexOf('accept', 0) === 0 && key !== 'accept-encoding')) {
+      newHeaders[key] = headers[key];
+    }
+  }
+  return newHeaders;
+}
+
+function renderURL(url, headers, options, callback) {
+  var timeout = (options && options.timeout ? options.timeout : 5000);
+  var cookieDomain = options && options.cookieDomain;
+  request({
+    uri: urlLib.parse(url),
+    headers: filterHeaders(headers)
+  }, function(err, res, body) {
+    if (err) {
+      callback(err);
+      return;
+    }
+    if (res.statusCode != 200) {
+      callback(res.statusCode);
+      return;
+    }
+    var document;
+    var timer = null;
+    var done = function() {
+      if (timer) {
+        clearTimeout(timer);
+        timer = null;
+        var content;
+        try {
+          document.body.setAttribute('data-prerendered', 'true');
+          content = jsdom.serializeDocument(document);
+        }
+        catch (err) {
+          return callback(err);
+        }
+        callback(null, content, res.headers);
+      }
+    };
+
+    timer = setTimeout(function() {
+      console.error('prerenderer[err]: Timouted after ' + timeout + 'ms…');
+      done();
+    }, timeout);
+    try {
+      document = jsdom.jsdom(body, {
+        url: url,
+        cookie: headers.cookie,
+        cookieDomain: cookieDomain,
+        features: {
+          FetchExternalResources: ['script'],
+          ProcessExternalResources: ['script']
+        }
+      });
+      if (options && options.attachConsole) {
+        document.parentWindow.console.log = function() {
+          Array.prototype.unshift.call(arguments, 'prerenderer[out]:');
+          console.error.apply(console, arguments);
+        };
+        document.parentWindow.console.error = function() {
+          Array.prototype.unshift.call(arguments, 'prerenderer[err]:');
+          console.error.apply(console, arguments);
+        };
+      }
+      document.onprerendered = done;
+    } catch (err) {
+      if (timer) {
+        clearTimeout(timer);
+        timer = null;
+      }
+      callback(err);
+      return;
+    }
+  });
+}
+
+var args = [];
+
+try {
+  args = JSON.parse(process.argv[2] || '[]');
+}
+catch (e) {
+  console.log(JSON.stringify([e.stack]));
+  process.exit(1);
+}
+
+if (args.length !== 3) {
+  console.log('["Bad argument"]');
+  process.exit(1);
+}
+
+args.push(function(err, content, headers) {
+  console.log(JSON.stringify([err && err.stack, content, headers]));
+  process.exit(0);
+});
+
+renderURL.apply(null, args);


### PR DESCRIPTION
* Make this package work properly with node 0.12 by upgrading jsdom a lot
* Fix part of the memory leaks happening with prerenderer: `deferClose` was removed but if timers or events were created by asynchronously loaded scripts they were remaining in RAM (&run periodically). Calling close later on clear those properly. They are still a lot of memory leaks though.

It is maybe a good idea to execute a separate script to do the rendering and to kill it afterward thus preventing any memory leaks from polluting the main script. This would also prevent jsdom from freezing the main process thread with its calculation.

I will probably start working on this.