### PR TITLE
fix attachConsole option for new jsdom

### DIFF
--- a/connect-prerenderer.js
+++ b/connect-prerenderer.js
@@ -80,10 +80,10 @@ function getTargetURL(req, options) {
 }
 
 function prerenderer(options) {
-  var renderURL = ((options || {}).subprocess || process.env.RENDERER_USE_SUBPROCESS) ?
-    renderer.subprocessRenderURL :
-    renderer.renderURL
-  ;
+  options = options || {};
+
+  var useSubprocess = 'subprocess' in options ? !!options.subprocess : !!process.env.RENDERER_USE_SUBPROCESS;
+  var renderURL = useSubprocess ? renderer.subprocessRenderURL : renderer.renderURL;
 
   return function(req, res, next) {
     var url = getTargetURL(req, options);
@@ -111,10 +111,10 @@ function prerenderer(options) {
   };
 }
 
+module.exports = prerenderer;
+
 if (process.env.NODE_ENV === 'unit-test') {
-  exports.getTargetURL = getTargetURL;
-  exports.renderURL = process.env.RENDERER_USE_SUBPROCESS ? renderer.subprocessRenderURL : renderer.renderURL;
-  exports.prerenderer = prerenderer;
-} else {
-  module.exports = prerenderer;
+  module.exports.getTargetURL = getTargetURL;
+  module.exports.renderURL = process.env.RENDERER_USE_SUBPROCESS ? renderer.subprocessRenderURL : renderer.renderURL;
+  module.exports.prerenderer = prerenderer;
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "connect-prerenderer",
   "description": "Express/connect middleware to pre-render ajax page for non-ajax browsers, especially using angular.js",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "author": "Daishi Kato <daishi@axlight.com>",
   "dependencies": {
     "jsdom": "8.2.0",

--- a/test/server/app.js
+++ b/test/server/app.js
@@ -23,7 +23,6 @@ app.get('/data.json', function(req, res) {
   });
 });
 
-
 app.listen(process.env.PORT || 5050);
 
 //

--- a/test/server/public/console.html
+++ b/test/server/public/console.html
@@ -1,0 +1,10 @@
+<html>
+  <head>
+    <title>console</title>
+    <script>
+console.log('test');
+    </script>
+  </head>
+  <body>
+  </body>
+</html>

--- a/test/unitTest.js
+++ b/test/unitTest.js
@@ -3,7 +3,16 @@ var assert = require('assert');
 process.env.NODE_ENV = 'unit-test';
 var prerenderer = require('../connect-prerenderer.js');
 
+var spawn = require('child_process').spawn;
+
 describe('unit test for prerenderer', function() {
+  var server = null;
+  before(function() {
+    server = spawn(process.argv[0], [__dirname + '/server/app.js'], {stdio: 'inherit'});
+  });
+  after(function() {
+    server.kill('SIGKILL');
+  });
 
   it('should get target url without options', function() {
     assert.equal(prerenderer.getTargetURL({
@@ -68,6 +77,22 @@ describe('unit test for prerenderer', function() {
     prerenderer.renderURL('http://www.google.com/', {}, {timeout: 1000}, function(err, content) {
       assert.ok(content.indexOf('google.com') >= 0);
       done();
+    });
+  });
+
+  if (process.env.RENDERER_USE_SUBPROCESS)
+    return;
+
+  it('should accept attachConsole option', function(done) {
+    var oldErr = console.error;
+    var text = '';
+    console.error = function() {
+      text += [].slice.call(arguments).join(' ') + '\n';
+    };
+    prerenderer.renderURL('http://localhost:5050/console.html', {}, {attachConsole: true, timeout: 1000}, function(err, content) {
+      console.error = oldErr;
+      assert.ok(text.indexOf('prerenderer[out]: test') >= 0);
+      done(err);
     });
   });
 

--- a/urlRenderer.js
+++ b/urlRenderer.js
@@ -64,18 +64,21 @@ function renderURL(url, headers, options, callback) {
           FetchExternalResources: ['script'],
           ProcessExternalResources: ['script']
         },
+        created: function(err, window) {
+          if (err) return;
+          if (options && options.attachConsole) {
+            window.console.log = function() {
+              Array.prototype.unshift.call(arguments, 'prerenderer[out]:');
+              console.error.apply(console, arguments);
+            };
+            window.console.error = function() {
+              Array.prototype.unshift.call(arguments, 'prerenderer[err]:');
+              console.error.apply(console, arguments);
+            };
+          }
+        },
         done: done
       });
-      if (options && options.attachConsole) {
-        document.parentWindow.console.log = function() {
-          Array.prototype.unshift.call(arguments, 'prerenderer[out]:');
-          console.error.apply(console, arguments);
-        };
-        document.parentWindow.console.error = function() {
-          Array.prototype.unshift.call(arguments, 'prerenderer[err]:');
-          console.error.apply(console, arguments);
-        };
-      }
       document.onprerendered = done;
     } catch (err) {
       if (timer) {


### PR DESCRIPTION
The option was failing because on recent jsdom versions, document.parentWindow is not accessible right away. You need to use one of the provided lifecycle callbacks to do this properly.

I'm sorry for missing this when I updated everything.
